### PR TITLE
namespace: separate labeled and bare metrics

### DIFF
--- a/gauge.go
+++ b/gauge.go
@@ -4,20 +4,69 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // Gauge is a metric that allows incrementing and decrementing a value
 type Gauge interface {
+	Inc(...float64)
+	Dec(...float64)
+
 	// Add adds the provided value to the gauge's current value
-	Add(float64, map[string]string)
+	Add(float64)
+
 	// Set replaces the gauge's current value with the provided value
-	Set(float64, map[string]string)
+	Set(float64)
 }
 
-type gauge struct {
+// LabeledGauge describes a gauge the must have values populated before use.
+type LabeledGauge interface {
+	WithValues(labels ...string) Gauge
+}
+
+type labeledGauge struct {
 	pg *prometheus.GaugeVec
 }
 
-func (g *gauge) Add(v float64, labels map[string]string) {
-	g.pg.With(prometheus.Labels(labels)).Add(v)
+func (lg *labeledGauge) WithValues(labels ...string) Gauge {
+	return &gauge{pg: lg.pg.WithLabelValues(labels...)}
 }
 
-func (g *gauge) Set(v float64, labels map[string]string) {
-	g.pg.With(prometheus.Labels(labels)).Set(v)
+func (lg *labeledGauge) Describe(c chan<- *prometheus.Desc) {
+	lg.pg.Describe(c)
+}
+
+func (lg *labeledGauge) Collect(c chan<- prometheus.Metric) {
+	lg.pg.Collect(c)
+}
+
+type gauge struct {
+	pg prometheus.Gauge
+}
+
+func (g *gauge) Inc(vs ...float64) {
+	if len(vs) == 0 {
+		g.pg.Inc()
+	}
+
+	g.Add(sumFloat64(vs...))
+}
+
+func (g *gauge) Dec(vs ...float64) {
+	if len(vs) == 0 {
+		g.pg.Dec()
+	}
+
+	g.Add(-sumFloat64(vs...))
+}
+
+func (g *gauge) Add(v float64) {
+	g.pg.Add(v)
+}
+
+func (g *gauge) Set(v float64) {
+	g.pg.Set(v)
+}
+
+func (g *gauge) Describe(c chan<- *prometheus.Desc) {
+	g.pg.Describe(c)
+}
+
+func (g *gauge) Collect(c chan<- prometheus.Metric) {
+	g.pg.Collect(c)
 }

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,10 @@
+package metrics
+
+func sumFloat64(vs ...float64) float64 {
+	var sum float64
+	for _, v := range vs {
+		sum += v
+	}
+
+	return sum
+}

--- a/namespace.go
+++ b/namespace.go
@@ -7,89 +7,153 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+type Labels map[string]string
+
 // NewNamespace returns a namespaces that is responsible for managing a collection of
 // metrics for a particual namespace and subsystem
 //
 // labels allows const labels to be added to all metrics created in this namespace
 // and are commonly used for data like application version and git commit
-func NewNamespace(name, subsystem string, labels map[string]string) Namespace {
+func NewNamespace(name, subsystem string, labels Labels) *Namespace {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	return &namespace{
+	return &Namespace{
 		name:      name,
 		subsystem: subsystem,
 		labels:    labels,
 	}
 }
 
-// Namespace is a collection of metrics under a common namespace and subsystem
-type Namespace interface {
-	// NewCounter returns a new Counter with the provided name and help string along with the keys
-	// of any dynamic labels what will be used with the counter
-	NewCounter(name, help string, labels []string) Counter
-	// NewTimer returns a new Timer with the provided name and help string along with the keys
-	// of any dynamic labels what will be used with the timer
-	NewTimer(name, help string, labels []string) Timer
-	// NewGauge returns a new Gauge with the provided name and help string along with the keys
-	// of any dynamic labels what will be used with the gauge
-	NewGauge(name, help string, unit Unit, labels []string) Gauge
-
-	getMetrics() []prometheus.Collector
-}
-
-type namespace struct {
+// Namespace describes a set of metrics that share a namespace and subsystem.
+type Namespace struct {
 	name      string
 	subsystem string
-	labels    map[string]string
+	labels    Labels
 	mu        sync.Mutex
 	metrics   []prometheus.Collector
 }
 
-func (n *namespace) NewCounter(name, help string, labels []string) Counter {
-	c := prometheus.NewCounterVec(prometheus.CounterOpts{
+// WithConstLabels returns a namespace with the provided set of labels merged
+// with the existing constant labels on the namespace.
+//
+//  Only metrics created with the returned namespace will get the new constant
+//  labels.  The returned namespace must be registered separately.
+func (n *Namespace) WithConstLabels(labels Labels) *Namespace {
+	ns := *n
+	ns.metrics = nil // blank this out
+	ns.labels = mergeLabels(ns.labels, labels)
+	return &ns
+}
+
+func (n *Namespace) NewCounter(name, help string) Counter {
+	c := &counter{pc: prometheus.NewCounter(n.newCounterOpts(name, help))}
+	n.addMetric(c)
+	return c
+}
+
+func (n *Namespace) NewLabeledCounter(name, help string, labels ...string) LabeledCounter {
+	c := &labeledCounter{pc: prometheus.NewCounterVec(n.newCounterOpts(name, help), labels)}
+	n.addMetric(c)
+	return c
+}
+
+func (n *Namespace) newCounterOpts(name, help string) prometheus.CounterOpts {
+	return prometheus.CounterOpts{
 		Namespace:   n.name,
 		Subsystem:   n.subsystem,
 		Name:        fmt.Sprintf("%s_%s", name, Total),
 		Help:        help,
 		ConstLabels: prometheus.Labels(n.labels),
-	}, labels)
-	n.mu.Lock()
-	n.metrics = append(n.metrics, c)
-	n.mu.Unlock()
-	return &counter{pc: c}
+	}
 }
 
-func (n *namespace) NewTimer(name, help string, labels []string) Timer {
+func (n *Namespace) NewTimer(name, help string) Timer {
 	t := &timer{
-		m: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace:   n.name,
-			Subsystem:   n.subsystem,
-			Name:        fmt.Sprintf("%s_%s", name, Seconds),
-			Help:        help,
-			ConstLabels: prometheus.Labels(n.labels),
-		}, labels),
+		m: prometheus.NewHistogram(n.newTimerOpts(name, help)),
 	}
-	n.mu.Lock()
-	n.metrics = append(n.metrics, t)
-	n.mu.Unlock()
+	n.addMetric(t)
 	return t
 }
 
-func (n *namespace) NewGauge(name, help string, unit Unit, labels []string) Gauge {
-	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+func (n *Namespace) NewLabeledTimer(name, help string, labels ...string) LabeledTimer {
+	t := &labeledTimer{
+		m: prometheus.NewHistogramVec(n.newTimerOpts(name, help), labels),
+	}
+	n.addMetric(t)
+	return t
+}
+
+func (n *Namespace) newTimerOpts(name, help string) prometheus.HistogramOpts {
+	return prometheus.HistogramOpts{
+		Namespace:   n.name,
+		Subsystem:   n.subsystem,
+		Name:        fmt.Sprintf("%s_%s", name, Seconds),
+		Help:        help,
+		ConstLabels: prometheus.Labels(n.labels),
+	}
+}
+
+func (n *Namespace) NewGauge(name, help string, unit Unit) Gauge {
+	g := &gauge{
+		pg: prometheus.NewGauge(n.newGaugeOpts(name, help, unit)),
+	}
+	n.addMetric(g)
+	return g
+}
+
+func (n *Namespace) NewLabeledGauge(name, help string, unit Unit, labels ...string) LabeledGauge {
+	g := &labeledGauge{
+		pg: prometheus.NewGaugeVec(n.newGaugeOpts(name, help, unit), labels),
+	}
+	n.addMetric(g)
+	return g
+}
+
+func (n *Namespace) newGaugeOpts(name, help string, unit Unit) prometheus.GaugeOpts {
+	return prometheus.GaugeOpts{
 		Namespace:   n.name,
 		Subsystem:   n.subsystem,
 		Name:        fmt.Sprintf("%s_%s", name, unit),
 		Help:        help,
 		ConstLabels: prometheus.Labels(n.labels),
-	}, labels)
-	n.mu.Lock()
-	n.metrics = append(n.metrics, g)
-	n.mu.Unlock()
-	return &gauge{pg: g}
+	}
 }
 
-func (n *namespace) getMetrics() []prometheus.Collector {
-	return n.metrics
+func (n *Namespace) Describe(ch chan<- *prometheus.Desc) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	for _, metric := range n.metrics {
+		metric.Describe(ch)
+	}
+}
+
+func (n *Namespace) Collect(ch chan<- prometheus.Metric) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	for _, metric := range n.metrics {
+		metric.Collect(ch)
+	}
+}
+
+func (n *Namespace) addMetric(collector prometheus.Collector) {
+	n.mu.Lock()
+	n.metrics = append(n.metrics, collector)
+	n.mu.Unlock()
+}
+
+// mergeLabels merges two or more labels objects into a single map, favoring
+// the later labels.
+func mergeLabels(lbs ...Labels) Labels {
+	merged := make(Labels)
+
+	for _, target := range lbs {
+		for k, v := range target {
+			merged[k] = v
+		}
+	}
+
+	return merged
 }

--- a/register.go
+++ b/register.go
@@ -4,16 +4,12 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // Register adds all the metrics in the provided namespace to the global
 // metrics registry
-func Register(n Namespace) {
-	for _, m := range n.getMetrics() {
-		prometheus.MustRegister(m)
-	}
+func Register(n *Namespace) {
+	prometheus.MustRegister(n)
 }
 
 // Deregister removes all the metrics in the provided namespace from the
 // global metrics registry
-func Deregister(n Namespace) {
-	for _, m := range n.getMetrics() {
-		prometheus.Unregister(m)
-	}
+func Deregister(n *Namespace) {
+	prometheus.Unregister(n)
 }

--- a/timer.go
+++ b/timer.go
@@ -8,10 +8,10 @@ import (
 
 // StartTimer begins a timer observation at the callsite. When the target
 // operation is completed, the caller should call the return done func().
-func StartTimer(timer Timer, labels map[string]string) (done func()) {
+func StartTimer(timer Timer) (done func()) {
 	start := time.Now()
 	return func() {
-		timer.Update(time.Since(start), labels)
+		timer.Update(time.Since(start))
 	}
 }
 
@@ -19,23 +19,44 @@ func StartTimer(timer Timer, labels map[string]string) (done func()) {
 type Timer interface {
 	// Update records an observation, duration, and converts to the target
 	// units.
-	Update(duration time.Duration, labels map[string]string)
+	Update(duration time.Duration)
 
 	// UpdateSince will add the duration from the provided starting time to the
 	// timer's summary with the precisions that was used in creation of the timer
-	UpdateSince(time.Time, map[string]string)
+	UpdateSince(time.Time)
 }
 
-type timer struct {
+// LabeledTimer is a timer that must have label values populated before use.
+type LabeledTimer interface {
+	WithValues(labels ...string) Timer
+}
+
+type labeledTimer struct {
 	m *prometheus.HistogramVec
 }
 
-func (t *timer) Update(duration time.Duration, labels map[string]string) {
-	t.m.With(prometheus.Labels(labels)).Observe(duration.Seconds())
+func (lt *labeledTimer) WithValues(labels ...string) Timer {
+	return &timer{m: lt.m.WithLabelValues(labels...)}
 }
 
-func (t *timer) UpdateSince(since time.Time, labels map[string]string) {
-	t.m.With(prometheus.Labels(labels)).Observe(time.Since(since).Seconds())
+func (lt *labeledTimer) Describe(c chan<- *prometheus.Desc) {
+	lt.m.Describe(c)
+}
+
+func (lt *labeledTimer) Collect(c chan<- prometheus.Metric) {
+	lt.m.Collect(c)
+}
+
+type timer struct {
+	m prometheus.Histogram
+}
+
+func (t *timer) Update(duration time.Duration) {
+	t.m.Observe(duration.Seconds())
+}
+
+func (t *timer) UpdateSince(since time.Time) {
+	t.m.Observe(time.Since(since).Seconds())
 }
 
 func (t *timer) Describe(c chan<- *prometheus.Desc) {


### PR DESCRIPTION
Namespace is refactored into a concrete factory type that allows callers
to create labeled and unlabeled metrics. Namespaces can be declared with
all metrics with constant labels from the start or can be broken apart
using `WithConstLabels` to have different sets of constant labels for
child metrics.

Metrics requiring labels must now explicitly set the labels before using
the actual counter. We use the convention `Metrics` and `LabeledMetric`
to differentiate these types. Users of the metric must supply label
values to the `WithValues` function, in order. This interface may be
slightly error prone but allows for zero allocation workflows on metric
reporting.

All metrics now implement `prometheus.Collector`, including `Namespace`,
which allows registering metrics individually or as group with
`Namespace`.

Signed-off-by: Stephen J Day stephen.day@docker.com

cc @crosbymichael 
