### PR TITLE
Expose the Gatherer and use new registry over prometheus default registry

### DIFF
--- a/counter_test.go
+++ b/counter_test.go
@@ -1,0 +1,61 @@
+package metrics
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestCounter(t *testing.T) {
+	expected := struct {
+		Name  string
+		Help  string
+		Type  dto.MetricType
+		Value float64
+	}{
+		"test_counter_counter_total",
+		"count all the things",
+		dto.MetricType_COUNTER,
+		5,
+	}
+
+	ns := NewNamespace("test", "counter", nil)
+
+	c := ns.NewCounter("counter", "count all the things")
+	c.Inc(5)
+
+	Register(ns)
+	defer Deregister(ns)
+
+	mfs, err := Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mfs) != 1 {
+		t.Fatalf("expected one metric family but got %d", len(mfs))
+	}
+
+	family := mfs[0]
+	if *family.Name != expected.Name {
+		t.Fatalf("expected name `%s` but got `%s`", expected.Name, *family.Name)
+	}
+
+	if *family.Help != expected.Help {
+		t.Fatalf("expected help `%s` but got `%s`", expected.Help, *family.Help)
+	}
+
+	if *family.Type != expected.Type {
+		t.Fatalf("expected type `%d` but got `%d`", expected.Type, *family.Type)
+	}
+
+	if len(family.Metric) != 1 {
+		t.Fatalf("expected one metric but got %d", len(family.Metric))
+	}
+
+	metric := family.Metric[0]
+	value := metric.GetCounter().GetValue()
+	if value != expected.Value {
+		t.Fatalf("expected counter value %f but got %f", expected.Value, value)
+	}
+}

--- a/gather.go
+++ b/gather.go
@@ -1,0 +1,17 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// Gatherer returns the metric gatherer
+func Gatherer() prometheus.Gatherer {
+	return registry
+}
+
+// Gather calls the gatherer to return all the metric families of
+// every metric in the registry.
+func Gather() ([]*dto.MetricFamily, error) {
+	return Gatherer().Gather()
+}

--- a/handler.go
+++ b/handler.go
@@ -3,11 +3,11 @@ package metrics
 import (
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Handler returns the global http.Handler that provides the prometheus
 // metrics format on GET requests
 func Handler() http.Handler {
-	return prometheus.Handler()
+	return promhttp.HandlerFor(Gatherer(), promhttp.HandlerOpts{})
 }

--- a/register.go
+++ b/register.go
@@ -1,15 +1,13 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
-
 // Register adds all the metrics in the provided namespace to the global
 // metrics registry
 func Register(n *Namespace) {
-	prometheus.MustRegister(n)
+	registry.MustRegister(n)
 }
 
 // Deregister removes all the metrics in the provided namespace from the
 // global metrics registry
 func Deregister(n *Namespace) {
-	prometheus.Unregister(n)
+	registry.Unregister(n)
 }

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,7 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	registry = prometheus.NewRegistry()
+)


### PR DESCRIPTION
closes #6 

This PR provides a means to get the Registerer and Gatherer being used by the package. It also eliminates using the default prometheus registry. This means that things like the GC handler included in the default registry won't be exported on `/metrics` or `Gather()`. This gives support for the package to include it optionally (say debug mode in docker). 

Signed-off-by: Josh Horwitz horwitzja@gmail.com
