### PR TITLE
Add functions that instruments http handler using promhttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ If you need to use a unit but it is not defined in the package please open a PR 
 
 Package documentation can be found [here](https://godoc.org/github.com/docker/go-metrics).
 
+## HTTP Metrics
+
+To instrument a http handler, you can wrap the code like this:
+
+```go
+namespace := metrics.NewNamespace("docker_distribution", "http", metrics.Labels{"handler": "your_http_handler_name"})
+httpMetrics := namespace.NewDefaultHttpMetrics()
+metrics.Register(namespace)
+instrumentedHandler = metrics.InstrumentHandler(httpMetrics, unInstrumentedHandler)
+```
+Note: The `handler` label must be provided when a new namespace is created.
+
 ## Additional Metrics
 
 Additional metrics are also defined here that are not available in the prometheus client.

--- a/handler.go
+++ b/handler.go
@@ -28,7 +28,7 @@ type HTTPMetric struct {
 }
 
 var (
-	defaultDurationBuckets     = []float64{0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1., 2., 5., 10., 20., 30., 40., 50.}
+	defaultDurationBuckets     = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 60}
 	defaultRequestSizeBuckets  = prometheus.ExponentialBuckets(1024, 2, 22) //1K to 4G
 	defaultResponseSizeBuckets = defaultRequestSizeBuckets
 )

--- a/handler.go
+++ b/handler.go
@@ -7,8 +7,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// HttpHandlerOpts describes a set of configurable options of http metrics
-type HttpHandlerOpts struct {
+// HTTPHandlerOpts describes a set of configurable options of http metrics
+type HTTPHandlerOpts struct {
 	DurationBuckets     []float64
 	RequestSizeBuckets  []float64
 	ResponseSizeBuckets []float64
@@ -22,7 +22,7 @@ const (
 	InstrumentHandlerInFlight
 )
 
-type HttpMetric struct {
+type HTTPMetric struct {
 	prometheus.Collector
 	handlerType int
 }
@@ -39,11 +39,11 @@ func Handler() http.Handler {
 	return promhttp.Handler()
 }
 
-func InstrumentHandler(metrics []*HttpMetric, handler http.Handler) http.HandlerFunc {
+func InstrumentHandler(metrics []*HTTPMetric, handler http.Handler) http.HandlerFunc {
 	return InstrumentHandlerFunc(metrics, handler.ServeHTTP)
 }
 
-func InstrumentHandlerFunc(metrics []*HttpMetric, handlerFunc http.HandlerFunc) http.HandlerFunc {
+func InstrumentHandlerFunc(metrics []*HTTPMetric, handlerFunc http.HandlerFunc) http.HandlerFunc {
 	var handler http.Handler
 	handler = http.HandlerFunc(handlerFunc)
 	for _, metric := range metrics {

--- a/handler.go
+++ b/handler.go
@@ -4,10 +4,71 @@ import (
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// HttpHandlerOpts describes a set of configurable options of http metrics
+type HttpHandlerOpts struct {
+	DurationBuckets     []float64
+	RequestSizeBuckets  []float64
+	ResponseSizeBuckets []float64
+}
+
+const (
+	InstrumentHandlerResponseSize = iota
+	InstrumentHandlerRequestSize
+	InstrumentHandlerDuration
+	InstrumentHandlerCounter
+	InstrumentHandlerInFlight
+)
+
+type HttpMetric struct {
+	prometheus.Collector
+	handlerType int
+}
+
+var (
+	defaultDurationBuckets     = []float64{0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1., 2., 5., 10., 20., 30., 40., 50.}
+	defaultRequestSizeBuckets  = prometheus.ExponentialBuckets(1024, 2, 22) //1K to 4G
+	defaultResponseSizeBuckets = defaultRequestSizeBuckets
 )
 
 // Handler returns the global http.Handler that provides the prometheus
-// metrics format on GET requests
+// metrics format on GET requests. This handler is no longer instrumented.
 func Handler() http.Handler {
-	return prometheus.Handler()
+	return promhttp.Handler()
+}
+
+func InstrumentHandler(metrics []*HttpMetric, handler http.Handler) http.HandlerFunc {
+	return InstrumentHandlerFunc(metrics, handler.ServeHTTP)
+}
+
+func InstrumentHandlerFunc(metrics []*HttpMetric, handlerFunc http.HandlerFunc) http.HandlerFunc {
+	var handler http.Handler
+	handler = http.HandlerFunc(handlerFunc)
+	for _, metric := range metrics {
+		switch metric.handlerType {
+		case InstrumentHandlerResponseSize:
+			if collector, ok := metric.Collector.(prometheus.ObserverVec); ok {
+				handler = promhttp.InstrumentHandlerResponseSize(collector, handler)
+			}
+		case InstrumentHandlerRequestSize:
+			if collector, ok := metric.Collector.(prometheus.ObserverVec); ok {
+				handler = promhttp.InstrumentHandlerRequestSize(collector, handler)
+			}
+		case InstrumentHandlerDuration:
+			if collector, ok := metric.Collector.(prometheus.ObserverVec); ok {
+				handler = promhttp.InstrumentHandlerDuration(collector, handler)
+			}
+		case InstrumentHandlerCounter:
+			if collector, ok := metric.Collector.(*prometheus.CounterVec); ok {
+				handler = promhttp.InstrumentHandlerCounter(collector, handler)
+			}
+		case InstrumentHandlerInFlight:
+			if collector, ok := metric.Collector.(prometheus.Gauge); ok {
+				handler = promhttp.InstrumentHandlerInFlight(collector, handler)
+			}
+		}
+	}
+	return handler.ServeHTTP
 }

--- a/namespace.go
+++ b/namespace.go
@@ -217,7 +217,10 @@ func (n *Namespace) NewInFlightGaugeMetric(handlerName string) *HTTPMetric {
 		Help:        "The in-flight HTTP requests",
 		ConstLabels: prometheus.Labels(labels),
 	})
-	httpMetric := &HTTPMetric{metric, InstrumentHandlerInFlight}
+	httpMetric := &HTTPMetric{
+		Collector:   metric,
+		handlerType: InstrumentHandlerInFlight,
+	}
 	n.Add(httpMetric)
 	return httpMetric
 }
@@ -235,7 +238,10 @@ func (n *Namespace) NewRequestTotalMetric(handlerName string) *HTTPMetric {
 		},
 		[]string{"code", "method"},
 	)
-	httpMetric := &HTTPMetric{metric, InstrumentHandlerCounter}
+	httpMetric := &HTTPMetric{
+		Collector:   metric,
+		handlerType: InstrumentHandlerCounter,
+	}
 	n.Add(httpMetric)
 	return httpMetric
 }
@@ -254,7 +260,10 @@ func (n *Namespace) NewRequestDurationMetric(handlerName string, buckets []float
 		ConstLabels: prometheus.Labels(labels),
 	}
 	metric := prometheus.NewHistogramVec(opts, []string{"method"})
-	httpMetric := &HTTPMetric{metric, InstrumentHandlerDuration}
+	httpMetric := &HTTPMetric{
+		Collector:   metric,
+		handlerType: InstrumentHandlerDuration,
+	}
 	n.Add(httpMetric)
 	return httpMetric
 }
@@ -274,7 +283,10 @@ func (n *Namespace) NewRequestSizeMetric(handlerName string, buckets []float64) 
 		ConstLabels: prometheus.Labels(labels),
 	}
 	metric := prometheus.NewHistogramVec(opts, []string{})
-	httpMetric := &HTTPMetric{metric, InstrumentHandlerRequestSize}
+	httpMetric := &HTTPMetric{
+		Collector:   metric,
+		handlerType: InstrumentHandlerRequestSize,
+	}
 	n.Add(httpMetric)
 	return httpMetric
 }
@@ -294,7 +306,10 @@ func (n *Namespace) NewResponseSizeMetric(handlerName string, buckets []float64)
 		ConstLabels: prometheus.Labels(labels),
 	}
 	metrics := prometheus.NewHistogramVec(opts, []string{})
-	httpMetric := &HTTPMetric{metrics, InstrumentHandlerResponseSize}
+	httpMetric := &HTTPMetric{
+		Collector:   metrics,
+		handlerType: InstrumentHandlerResponseSize,
+	}
 	n.Add(httpMetric)
 	return httpMetric
 }

--- a/namespace.go
+++ b/namespace.go
@@ -180,115 +180,121 @@ func makeName(name string, unit Unit) string {
 	return fmt.Sprintf("%s_%s", name, unit)
 }
 
-func (n *Namespace) NewDefaultHttpMetrics() []*HttpMetric {
-	return n.NewHttpMetricsWithOpts(HttpHandlerOpts{
+func (n *Namespace) NewDefaultHttpMetrics(handlerName string) []*HTTPMetric {
+	return n.NewHttpMetricsWithOpts(handlerName, HTTPHandlerOpts{
 		DurationBuckets:     defaultDurationBuckets,
 		RequestSizeBuckets:  defaultResponseSizeBuckets,
 		ResponseSizeBuckets: defaultResponseSizeBuckets,
 	})
 }
 
-func (n *Namespace) NewHttpMetrics(durationBuckets, requestSizeBuckets, responseSizeBuckets []float64) []*HttpMetric {
-	return n.NewHttpMetricsWithOpts(HttpHandlerOpts{
+func (n *Namespace) NewHttpMetrics(handlerName string, durationBuckets, requestSizeBuckets, responseSizeBuckets []float64) []*HTTPMetric {
+	return n.NewHttpMetricsWithOpts(handlerName, HTTPHandlerOpts{
 		DurationBuckets:     durationBuckets,
 		RequestSizeBuckets:  requestSizeBuckets,
 		ResponseSizeBuckets: responseSizeBuckets,
 	})
 }
 
-func (n *Namespace) NewHttpMetricsWithOpts(opts HttpHandlerOpts) []*HttpMetric {
-	if _, ok := n.labels["handler"]; !ok {
-		panic("label \"handler\" must be provided in the namespace")
-	}
-
-	var httpMetrics []*HttpMetric
-	inFlightMetric := n.NewInFlightGaugeMetric()
-	requestTotalMetric := n.NewRequestTotalMetric()
-	requestDurationMetric := n.NewRequestDurationMetric(opts.DurationBuckets)
-	requestSizeMetric := n.NewRequestSizeMetric(opts.RequestSizeBuckets)
-	responseSizeMetric := n.NewResponseSizeMetric(opts.ResponseSizeBuckets)
+func (n *Namespace) NewHttpMetricsWithOpts(handlerName string, opts HTTPHandlerOpts) []*HTTPMetric {
+	var httpMetrics []*HTTPMetric
+	inFlightMetric := n.NewInFlightGaugeMetric(handlerName)
+	requestTotalMetric := n.NewRequestTotalMetric(handlerName)
+	requestDurationMetric := n.NewRequestDurationMetric(handlerName, opts.DurationBuckets)
+	requestSizeMetric := n.NewRequestSizeMetric(handlerName, opts.RequestSizeBuckets)
+	responseSizeMetric := n.NewResponseSizeMetric(handlerName, opts.ResponseSizeBuckets)
 	httpMetrics = append(httpMetrics, inFlightMetric, requestDurationMetric, requestTotalMetric, requestSizeMetric, responseSizeMetric)
 	return httpMetrics
 }
 
-func (n *Namespace) NewInFlightGaugeMetric() *HttpMetric {
+func (n *Namespace) NewInFlightGaugeMetric(handlerName string) *HTTPMetric {
+	labels := prometheus.Labels(n.labels)
+	labels["handler"] = handlerName
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:   n.name,
 		Subsystem:   n.subsystem,
 		Name:        "in_flight_requests",
 		Help:        "The in-flight HTTP requests",
-		ConstLabels: prometheus.Labels(n.labels),
+		ConstLabels: prometheus.Labels(labels),
 	})
-	httpMetric := &HttpMetric{metric, InstrumentHandlerInFlight}
+	httpMetric := &HTTPMetric{metric, InstrumentHandlerInFlight}
 	n.Add(httpMetric)
 	return httpMetric
 }
 
-func (n *Namespace) NewRequestTotalMetric() *HttpMetric {
+func (n *Namespace) NewRequestTotalMetric(handlerName string) *HTTPMetric {
+	labels := prometheus.Labels(n.labels)
+	labels["handler"] = handlerName
 	metric := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace:   n.name,
 			Subsystem:   n.subsystem,
 			Name:        "requests_total",
 			Help:        "Total number of HTTP requests made.",
-			ConstLabels: prometheus.Labels(n.labels),
+			ConstLabels: prometheus.Labels(labels),
 		},
 		[]string{"code", "method"},
 	)
-	httpMetric := &HttpMetric{metric, InstrumentHandlerCounter}
+	httpMetric := &HTTPMetric{metric, InstrumentHandlerCounter}
 	n.Add(httpMetric)
 	return httpMetric
 }
-func (n *Namespace) NewRequestDurationMetric(buckets []float64) *HttpMetric {
+func (n *Namespace) NewRequestDurationMetric(handlerName string, buckets []float64) *HTTPMetric {
 	if len(buckets) == 0 {
 		panic("DurationBuckets must be provided")
 	}
+	labels := prometheus.Labels(n.labels)
+	labels["handler"] = handlerName
 	opts := prometheus.HistogramOpts{
 		Namespace:   n.name,
 		Subsystem:   n.subsystem,
 		Name:        "request_duration_seconds",
 		Help:        "The HTTP request latencies in seconds.",
 		Buckets:     buckets,
-		ConstLabels: prometheus.Labels(n.labels),
+		ConstLabels: prometheus.Labels(labels),
 	}
 	metric := prometheus.NewHistogramVec(opts, []string{"method"})
-	httpMetric := &HttpMetric{metric, InstrumentHandlerDuration}
+	httpMetric := &HTTPMetric{metric, InstrumentHandlerDuration}
 	n.Add(httpMetric)
 	return httpMetric
 }
 
-func (n *Namespace) NewRequestSizeMetric(buckets []float64) *HttpMetric {
+func (n *Namespace) NewRequestSizeMetric(handlerName string, buckets []float64) *HTTPMetric {
 	if len(buckets) == 0 {
 		panic("RequestSizeBuckets must be provided")
 	}
+	labels := prometheus.Labels(n.labels)
+	labels["handler"] = handlerName
 	opts := prometheus.HistogramOpts{
 		Namespace:   n.name,
 		Subsystem:   n.subsystem,
 		Name:        "request_size_bytes",
 		Help:        "The HTTP request sizes in bytes.",
 		Buckets:     buckets,
-		ConstLabels: prometheus.Labels(n.labels),
+		ConstLabels: prometheus.Labels(labels),
 	}
 	metric := prometheus.NewHistogramVec(opts, []string{})
-	httpMetric := &HttpMetric{metric, InstrumentHandlerRequestSize}
+	httpMetric := &HTTPMetric{metric, InstrumentHandlerRequestSize}
 	n.Add(httpMetric)
 	return httpMetric
 }
 
-func (n *Namespace) NewResponseSizeMetric(buckets []float64) *HttpMetric {
+func (n *Namespace) NewResponseSizeMetric(handlerName string, buckets []float64) *HTTPMetric {
 	if len(buckets) == 0 {
 		panic("ResponseSizeBuckets must be provided")
 	}
+	labels := prometheus.Labels(n.labels)
+	labels["handler"] = handlerName
 	opts := prometheus.HistogramOpts{
 		Namespace:   n.name,
 		Subsystem:   n.subsystem,
 		Name:        "response_size_bytes",
 		Help:        "The HTTP response sizes in bytes.",
 		Buckets:     buckets,
-		ConstLabels: prometheus.Labels(n.labels),
+		ConstLabels: prometheus.Labels(labels),
 	}
 	metrics := prometheus.NewHistogramVec(opts, []string{})
-	httpMetric := &HttpMetric{metrics, InstrumentHandlerResponseSize}
+	httpMetric := &HTTPMetric{metrics, InstrumentHandlerResponseSize}
 	n.Add(httpMetric)
 	return httpMetric
 }


### PR DESCRIPTION
In the latest prometheus go client, handlers  provided before in `prometheus` package are deprecated. Instead, `promhttp` package is recommended.

This PR implements functions that wraps original methods in`promhttp`.

It also fix the compilation error, when building against `prometheus/client-golang` master.