### PR TITLE
metrics: address compile error correctly

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -48,7 +48,7 @@ func (lt *labeledTimer) Collect(c chan<- prometheus.Metric) {
 }
 
 type timer struct {
-	m prometheus.Histogram
+	m prometheus.Observer
 }
 
 func (t *timer) Update(duration time.Duration) {
@@ -60,9 +60,14 @@ func (t *timer) UpdateSince(since time.Time) {
 }
 
 func (t *timer) Describe(c chan<- *prometheus.Desc) {
-	t.m.Describe(c)
+	c <- t.m.(prometheus.Metric).Desc()
 }
 
 func (t *timer) Collect(c chan<- prometheus.Metric) {
-	t.m.Collect(c)
+	// Are there any observers that don't implement Collector? It is really
+	// unclear what the point of the upstream change was, but we'll let this
+	// panic if we get an observer that doesn't implement collector. In this
+	// case, we should almost always see metricVec objects, so this should
+	// never panic.
+	t.m.(prometheus.Collector).Collect(c)
 }


### PR DESCRIPTION
This addresses a compilation error without breaking the interface. In
both cases, the returned metric, of type Observer, is always a Collector
and a Metric, preserving the original behavior of the package.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #12