### PR TITLE
Namespace: enable creation of Timers with custom buckets

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -74,7 +74,15 @@ func (n *Namespace) newCounterOpts(name, help string) prometheus.CounterOpts {
 
 func (n *Namespace) NewTimer(name, help string) Timer {
 	t := &timer{
-		m: prometheus.NewHistogram(n.newTimerOpts(name, help)),
+		m: prometheus.NewHistogram(n.newTimerOpts(name, help, []float64{})),
+	}
+	n.Add(t)
+	return t
+}
+
+func (n *Namespace) NewTimerWithBuckets(name, help string, buckets []float64) Timer {
+	t := &timer{
+		m: prometheus.NewHistogram(n.newTimerOpts(name, help, buckets)),
 	}
 	n.Add(t)
 	return t
@@ -82,20 +90,32 @@ func (n *Namespace) NewTimer(name, help string) Timer {
 
 func (n *Namespace) NewLabeledTimer(name, help string, labels ...string) LabeledTimer {
 	t := &labeledTimer{
-		m: prometheus.NewHistogramVec(n.newTimerOpts(name, help), labels),
+		m: prometheus.NewHistogramVec(n.newTimerOpts(name, help, []float64{}), labels),
 	}
 	n.Add(t)
 	return t
 }
 
-func (n *Namespace) newTimerOpts(name, help string) prometheus.HistogramOpts {
-	return prometheus.HistogramOpts{
+func (n *Namespace) NewLabeledTimerWithBuckets(name, help string, buckets []float64, labels ...string) LabeledTimer {
+	t := &labeledTimer{
+		m: prometheus.NewHistogramVec(n.newTimerOpts(name, help, buckets), labels),
+	}
+	n.Add(t)
+	return t
+}
+
+func (n *Namespace) newTimerOpts(name, help string, buckets []float64) prometheus.HistogramOpts {
+	opts := prometheus.HistogramOpts{
 		Namespace:   n.name,
 		Subsystem:   n.subsystem,
 		Name:        makeName(name, Seconds),
 		Help:        help,
 		ConstLabels: prometheus.Labels(n.labels),
 	}
+	if len(buckets) > 0 {
+		opts.Buckets = buckets
+	}
+	return opts
 }
 
 func (n *Namespace) NewGauge(name, help string, unit Unit) Gauge {


### PR DESCRIPTION
Timers created by this repo current default to [the default prometheus buckets](https://github.com/prometheus/client_golang/blob/2261d5cda14eb2adc5897b56996248705f9bb840/prometheus/histogram.go#L68), this PR makes it possible to pass in a non-default when creating timers.